### PR TITLE
Add basic transcription CLI and GUI

### DIFF
--- a/transcription_tool/README.md
+++ b/transcription_tool/README.md
@@ -1,0 +1,27 @@
+# Transcription Tool
+
+A minimal transcription utility that provides both a command-line interface and a PyQt5-based GUI. It relies on OpenAI's Whisper model for speech recognition.
+
+## CLI
+
+Run from the repository root:
+
+```bash
+python -m transcription_tool.transcribe_cli --duration 5
+```
+
+Provide an existing file instead of recording:
+
+```bash
+python -m transcription_tool.transcribe_cli --file path/to/audio.wav
+```
+
+## GUI
+
+Launch the GUI application:
+
+```bash
+python -m transcription_tool.gui_app
+```
+
+Dependencies include `whisper`, `sounddevice`, and `PyQt5`.

--- a/transcription_tool/__init__.py
+++ b/transcription_tool/__init__.py
@@ -1,0 +1,1 @@
+"""Simple transcription tool."""

--- a/transcription_tool/core_transcribe.py
+++ b/transcription_tool/core_transcribe.py
@@ -1,0 +1,46 @@
+"""Core utilities for audio recording and transcription."""
+
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import sounddevice as sd
+import whisper
+
+
+DEFAULT_SAMPLE_RATE = 16000
+
+
+def record_audio(duration: int = 5, samplerate: int = DEFAULT_SAMPLE_RATE) -> np.ndarray:
+    """Record audio from the default microphone."""
+    audio = sd.rec(int(duration * samplerate), samplerate=samplerate, channels=1)
+    sd.wait()
+    return np.squeeze(audio)
+
+
+def _save_temp_audio(audio: np.ndarray, samplerate: int) -> Path:
+    """Store audio data to a temporary WAV file and return its path."""
+    tmp = tempfile.NamedTemporaryFile(suffix=".wav", delete=False)
+    try:
+        whisper.audio.write_audio(tmp.name, audio, samplerate)
+    finally:
+        tmp.close()
+    return Path(tmp.name)
+
+
+def transcribe_audio(audio: np.ndarray, model_name: str = "base") -> str:
+    """Transcribe an in-memory numpy array."""
+    model = whisper.load_model(model_name)
+    tmp_file = _save_temp_audio(audio, DEFAULT_SAMPLE_RATE)
+    try:
+        result = model.transcribe(str(tmp_file))
+    finally:
+        tmp_file.unlink(missing_ok=True)
+    return result["text"].strip()
+
+
+def transcribe_file(path: str, model_name: str = "base") -> str:
+    """Transcribe an existing audio file."""
+    model = whisper.load_model(model_name)
+    result = model.transcribe(path)
+    return result["text"].strip()

--- a/transcription_tool/gui_app.py
+++ b/transcription_tool/gui_app.py
@@ -1,0 +1,36 @@
+"""Simple PyQt5 GUI for the transcription tool."""
+
+import sys
+from PyQt5.QtWidgets import QApplication, QWidget, QVBoxLayout, QPushButton, QTextEdit
+
+from .core_transcribe import record_audio, transcribe_audio
+
+
+class TranscriberGUI(QWidget):
+    def __init__(self) -> None:
+        super().__init__()
+        self.setWindowTitle("Transcription App")
+        self.text_area = QTextEdit()
+        self.record_btn = QPushButton("Record")
+        self.record_btn.clicked.connect(self.handle_record)
+
+        layout = QVBoxLayout()
+        layout.addWidget(self.record_btn)
+        layout.addWidget(self.text_area)
+        self.setLayout(layout)
+
+    def handle_record(self) -> None:
+        audio = record_audio()
+        text = transcribe_audio(audio)
+        self.text_area.setPlainText(text)
+
+
+def main() -> None:
+    app = QApplication(sys.argv)
+    gui = TranscriberGUI()
+    gui.show()
+    sys.exit(app.exec_())
+
+
+if __name__ == "__main__":
+    main()

--- a/transcription_tool/transcribe_cli.py
+++ b/transcription_tool/transcribe_cli.py
@@ -1,0 +1,25 @@
+"""Command line interface for the transcription tool."""
+
+import argparse
+
+from .core_transcribe import record_audio, transcribe_audio, transcribe_file
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="CLI transcription tool")
+    parser.add_argument("--duration", type=int, default=5, help="Record duration in seconds")
+    parser.add_argument("--file", type=str, help="Transcribe an existing audio file")
+    parser.add_argument("--model", type=str, default="base", help="Whisper model size")
+    args = parser.parse_args()
+
+    if args.file:
+        text = transcribe_file(args.file, model_name=args.model)
+    else:
+        audio = record_audio(duration=args.duration)
+        text = transcribe_audio(audio, model_name=args.model)
+
+    print("Transcription:\n" + text)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add core audio recording and transcription helpers using Whisper
- provide a command-line interface for recording or file-based transcription
- include a minimal PyQt5 GUI for desktop use

## Testing
- `python -m py_compile transcription_tool/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68b8efa30264832d8f2ca458a4af9b10